### PR TITLE
Use setDBIMethod()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Depends:
     dbplyr (>= 1.4.0)
 Imports:
     bit64,
-    DBI (>= 0.8),
+    DBI (>= 1.0.0.9003),
     methods, 
     odbc (>= 1.1.6),
     rstudioapi (>= 0.7)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,8 @@ Suggests:
     knitr,
     rmarkdown,
     testthat
+Remotes: 
+    r-dbi/DBI
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr

--- a/R/aaa-s4.R
+++ b/R/aaa-s4.R
@@ -1,0 +1,1 @@
+setMethod <- DBI::setDBIMethod


### PR DESCRIPTION
I'd like to rename the `con` argument to `sqlData()` to `conn` in r-dbi/DBI#285. This change allows me to do so in the future without introducing a breaking change which would be very unpleasant to deal with. Also, it opens up the potential to clean up the definition of the DBI interface.

See https://dbi.r-dbi.org/dev/reference/setdbimethod for details.